### PR TITLE
#7 - jpa Auditing

### DIFF
--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/WeWriteBApplication.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/WeWriteBApplication.java
@@ -2,7 +2,9 @@ package com.onemorethink.wewriteb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class WeWriteBApplication {
 

--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/config/BaseEntity.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/config/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.onemorethink.wewriteb.config;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(updatable=false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+}

--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/config/BaseTimeEntity.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/config/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.onemorethink.wewriteb.config;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseTimeEntity{
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/config/JpaConfig.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/config/JpaConfig.java
@@ -1,0 +1,18 @@
+package com.onemorethink.wewriteb.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+    @Bean // TODO: Spring Security를 통한 인증기능 수행시 수정 필요
+    public AuditorAware<String> auditorAware(){
+        return () -> Optional.of("fine");
+    }
+}

--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/domain/Chapter.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/domain/Chapter.java
@@ -1,15 +1,15 @@
 package com.onemorethink.wewriteb.domain;
 
 
+import com.onemorethink.wewriteb.config.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.ToString;
-import java.time.LocalDateTime;
 
 @Getter
 @ToString
 @Entity
-public class Chapter {
+public class Chapter extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,9 +25,4 @@ public class Chapter {
     @JoinColumn(name = "novel_id", nullable = false)
     private Novel novel;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = true)
-    private LocalDateTime updatedAt;
 }

--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/domain/Novel.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/domain/Novel.java
@@ -1,10 +1,10 @@
 package com.onemorethink.wewriteb.domain;
 
 
+import com.onemorethink.wewriteb.config.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.ToString;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -14,7 +14,7 @@ import java.util.List;
         @Index(columnList = "createdAt")
 })
 @Entity
-public class Novel {
+public class Novel extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,12 +35,5 @@ public class Novel {
 
     @OneToMany(mappedBy = "novel", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Chapter> chapters;
-
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = true)
-    private LocalDateTime updatedAt;
-
 
 }

--- a/WeWriteB/src/main/java/com/onemorethink/wewriteb/domain/User.java
+++ b/WeWriteB/src/main/java/com/onemorethink/wewriteb/domain/User.java
@@ -1,9 +1,9 @@
 package com.onemorethink.wewriteb.domain;
 
+import com.onemorethink.wewriteb.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.ToString;
-import java.time.LocalDateTime;
 
 
 @Getter
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
         @Index(columnList = "createdAt")
 })
 @Entity
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,9 +32,4 @@ public class User {
 //    @OneToMany(mappedBy = "author")
 //    private List<Novel> novels;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = true)
-    private LocalDateTime updateAt;
 }


### PR DESCRIPTION
- User, Novel, Chapter에 있던 auditing field 삭제
- JpaConfig에서 Aduitor 설정 ( Security와 수정필요)
- @Application 단에 @EnableJpaAuditing 추가
- TimeBaseEntity와 BaseEntity를 분리함으로써 각 엔티티에 맞게 auditing 적용가능